### PR TITLE
Fix output directory permissions

### DIFF
--- a/convert-webgl.go
+++ b/convert-webgl.go
@@ -34,8 +34,9 @@ func main() {
 		assetPath := strings.TrimPrefix(srcFilePath, SRCDIR)
 		dstFilePath := DSTDIR + assetPath
 
-		// Make sure the source path exists
-		err = os.MkdirAll(filepath.Dir(dstFilePath), 0666)
+		// Make sure the destination path exists
+		// Use 0755 so created directories are traversable
+		err = os.MkdirAll(filepath.Dir(dstFilePath), 0755)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary
- fix directory permissions when converting WebGL files

## Testing
- `go build`
- `node -c fetch.js`

------
https://chatgpt.com/codex/tasks/task_e_683fb29bbe888328b808907b8ec69ad2